### PR TITLE
ユーザー辞書にしかない読みを変換しようとしてもできない問題を修正

### DIFF
--- a/extension/dictionary_loader.js
+++ b/extension/dictionary_loader.js
@@ -179,7 +179,7 @@ Dictionary.prototype.lookup = function(reading) {
   var systemEntries = this.systemDict[reading] || [];
   var word_set = {};
   for (var i = 0; i < userEntries.length; i++) {
-    if (!word_set[systemEntries[i].word]) {
+    if (!word_set[userEntries[i].word]) {
       entries.push(userEntries[i]);
       word_set[userEntries[i].word] = true;
     }


### PR DESCRIPTION
再現方法

1. システム辞書に存在しない単語の読みを登録
2. その読みを変換しようとスペースキーを押下すると、変換されるかわりに半角スペースが入力される

background.htmlのコンソールに出力されるエラー:

![image](https://user-images.githubusercontent.com/21108/36647927-3b579a9c-1a41-11e8-8a1c-3c5247ec50a9.png)
